### PR TITLE
Fix request to access login route in backend

### DIFF
--- a/app/src/main/java/br/org/cesar/knot_setup_app/activity/splash/SplashPresenter.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/activity/splash/SplashPresenter.java
@@ -80,7 +80,7 @@ public class SplashPresenter implements Presenter{
     private void handleStateSuccess(State state){
         Log.d("DEV-LOG","State: " + state.getState());
         if(state.getState().equals("ready")){
-            this.request = "http://" + ip +":8080/api/devices";
+            this.request = "http://" + ip  + ":"+ this.port +"/api/devices";
             checkToken();
         }
         else{


### PR DESCRIPTION
Changed the login url to use the port received by the multicast DNS.

Closes #11.