### PR TITLE
Fix GET request routes

### DIFF
--- a/app/src/main/java/br/org/cesar/knot_setup_app/utils/Constants.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/utils/Constants.java
@@ -53,6 +53,7 @@ public class Constants{
     //USER PREFERENCES KEYS
     public static final String GATEWAY_IP = "gateway_ip";
     public static final String GATEWAY_PORT = "gateway_port";
+    public static final String GATEWAY_TOKEN = "gateway_token";
 
     //KEYS FOR BUNDLES
     public static final String OPERATION = "operation";

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/login/LoginPresenter.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/login/LoginPresenter.java
@@ -30,10 +30,10 @@ public class LoginPresenter implements Presenter{
         this.context = context;
 
         this.ip = dataManager.getInstance()
-                .getPreference().getSharedPreferenceString(context,"ip");
+                .getPreference().getSharedPreferenceString(context, Constants.GATEWAY_IP);
 
         this.port =
-                dataManager.getInstance().getPreference().getSharedPreferenceString(context, "port");
+                dataManager.getInstance().getPreference().getSharedPreferenceString(context, Constants.GATEWAY_PORT);
 
         this.request = "http://" + ip +":" + port +"/api/auth";
 

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/splash/SplashPresenter.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/splash/SplashPresenter.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import br.org.cesar.knot_setup_app.utils.Constants;
 import br.org.cesar.knot_setup_app.view.splash.SplashContract.ViewModel;
 import br.org.cesar.knot_setup_app.view.splash.SplashContract.Presenter;
 import br.org.cesar.knot_setup_app.data.DataManager;
@@ -33,15 +34,15 @@ public class SplashPresenter implements Presenter{
 
         this.token = dataManager.getInstance()
                 .getPersistentPreference()
-                .getSharedPreferenceString(context,"token");
+                .getSharedPreferenceString(context, Constants.GATEWAY_TOKEN);
 
         this.ip = dataManager.getInstance()
                 .getPreference()
-                .getSharedPreferenceString(context,"ip");
+                .getSharedPreferenceString(context, Constants.GATEWAY_IP);
 
         this.port = dataManager.getInstance()
                 .getPreference()
-                .getSharedPreferenceString(context,"port");
+                .getSharedPreferenceString(context, Constants.GATEWAY_PORT);
 
         this.request = "http://" + ip +":" + port +  "/api/state";
     }

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/thingRegistered/ThingPresenter.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/thingRegistered/ThingPresenter.java
@@ -28,14 +28,14 @@ public class  ThingPresenter implements Presenter{
 
         this.token = dataManager.getInstance()
                 .getPersistentPreference()
-                .getSharedPreferenceString(context,"token");
+                .getSharedPreferenceString(context, Constants.GATEWAY_TOKEN);
 
         this.ip = dataManager.getInstance()
                 .getPreference()
-                .getSharedPreferenceString(context,"ip");
+                .getSharedPreferenceString(context, Constants.GATEWAY_IP);
 
         this.port = dataManager.getInstance()
-                .getPreference().getSharedPreferenceString(context,"port");
+                .getPreference().getSharedPreferenceString(context, Constants.GATEWAY_PORT);
 
         this.request = "http://" + ip + ":" + port +"/api/devices";
     }


### PR DESCRIPTION
Two constant values were changed in the Constants file during a rebase
but these values were being used as hardcoded strings by some classes,
which were not updated, thus causing the app to make wrong api requests.