### PR TITLE
Change UI of activities with only one tab

### DIFF
--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/BaseActivity.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/BaseActivity.java
@@ -44,4 +44,11 @@ public abstract class BaseActivity extends AppCompatActivity {
         tabLayout.setupWithViewPager(viewPager);
     }
 
+    public void setTabBackground(int color) {
+        tabLayout.setBackgroundColor(color);
+    }
+
+    public void setTabIndicator(int color){
+        tabLayout.setSelectedTabIndicatorColor(color);
+    }
 }

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/ConfigureGatewayWifiActivity.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/ConfigureGatewayWifiActivity.java
@@ -22,6 +22,10 @@ public class ConfigureGatewayWifiActivity extends BaseActivity {
         tabs.add(tab);
 
         setupHeader(getString(R.string.configure_gateway_wifi_header_title), tabs);
+
+        int backgroundColor = getResources().getColor(R.color.colorKnotGreen);
+        setTabBackground(backgroundColor);
+        setTabIndicator(backgroundColor);
     }
 
 }

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/LoginActivity.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/LoginActivity.java
@@ -25,6 +25,10 @@ public class LoginActivity extends BaseActivity {
             tabs.add(tab);
 
             setupHeader(getString(R.string.login_header_title),tabs);
+
+            int backgroundColor = getResources().getColor(R.color.colorKnotGreen);
+            setTabBackground(backgroundColor);
+            setTabIndicator(backgroundColor);
     }
 
 }


### PR DESCRIPTION
Change activities that only use one tab to display as if there was no
tab and look like it's only a text. This was done to only reutilize the
same header layout to all activities and easily integrate the new UI to
the app workflow.