### PR TITLE
Add restart of thing after write of OT settings

### DIFF
--- a/app/src/main/java/br/org/cesar/knot_setup_app/utils/Constants.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/utils/Constants.java
@@ -11,6 +11,9 @@ public class Constants{
     public static final UUID MASTER_KEY_CHARACTERISTIC = UUID.fromString("a8a9e49c-aa9a-d441-9bec-817bb4900d35");
     public static final UUID IPV6_SERVICE = UUID.fromString("49601183-5db4-498b-b35a-e6ddbe1c1470");
     public static final UUID IPV6_CHARACTERISTIC = UUID.fromString("49601183-5db4-498b-b35a-e6ddbe1c1471");
+    public static final UUID RESET_SERVICE = UUID.fromString("81418ff3-7cc8-939a-644a-7405fb2bba70");
+    public static final UUID RESET_CHARACTERISTIC = UUID.fromString("81418ff3-7cc8-939a-644a-7405fb2bba71");
+    public static final String RESET_VALUE = "1";
 
     public static final UUID OT_SETTINGS_SERVICE_GATEWAY = UUID.fromString("a8a9e49c-aa9a-d441-9bec-817bb4900e30");
     public static final UUID CHANNEL_CHARACTERISTIC_GATEWAY = UUID.fromString("a8a9e49c-aa9a-d441-9bec-817bb4900d31");

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/configureDevice/ConfigureDevicePresenter.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/configureDevice/ConfigureDevicePresenter.java
@@ -284,6 +284,11 @@ public class ConfigureDevicePresenter implements Presenter{
                 value = getValue("ipv6");
                 LogWrapper.Log("ipv6= " + value, Log.DEBUG);
                 writeWrapper(Constants.IPV6_SERVICE,Constants.IPV6_CHARACTERISTIC,value);
+                break;
+            case 6:
+                valueBytes = stringToByteArrLittleEndian(Constants.RESET_VALUE, Constants.CHANNEL_CHARACTERISTIC_BYTE_SIZE);
+                LogWrapper.Log("restart= " + valueBytes, Log.DEBUG);
+                writeWrapper(Constants.RESET_SERVICE, Constants.RESET_CHARACTERISTIC, valueBytes);
                 writeDone = true;
         }
 


### PR DESCRIPTION
Restarts the thing after successfully writing the OT characteristics.

This was necessary because the thing only applied the changes of OT
settings after being reset, which led the users to have to manually
reset teir things by unplugging then from the power souce.