### PR TITLE
Fix GET request routes

### DIFF
--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/configureDevice/ConfigureDevicePresenter.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/configureDevice/ConfigureDevicePresenter.java
@@ -59,14 +59,14 @@ public class ConfigureDevicePresenter implements Presenter{
         String bearer,ip,port,request;
         bearer = dataManager.getInstance()
                 .getPersistentPreference()
-                .getSharedPreferenceString(context,"token");
+                .getSharedPreferenceString(context, Constants.GATEWAY_TOKEN);
 
         ip = dataManager.getInstance()
                 .getPreference()
-                .getSharedPreferenceString(context,"ip");
+                .getSharedPreferenceString(context, Constants.GATEWAY_IP);
 
         port = dataManager.getInstance()
-                .getPreference().getSharedPreferenceString(context,"port");
+                .getPreference().getSharedPreferenceString(context, Constants.GATEWAY_PORT);
 
         request = "http://" + ip + ":" + port +"/api/radio/openthread";
         LogWrapper.Log("bearer= " + bearer, Log.DEBUG);

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/login/LoginPresenter.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/login/LoginPresenter.java
@@ -74,7 +74,7 @@ public class LoginPresenter implements Presenter{
                 .setSharedPreferenceString(context, "email",email);
 
         dataManager.getInstance().getPersistentPreference()
-                .setSharedPreferenceString(context,"token","Bearer " + user.getToken());
+                .setSharedPreferenceString(context, Constants.GATEWAY_TOKEN,"Bearer " + user.getToken());
 
         mViewModel.onLogin();
     }


### PR DESCRIPTION
Three constant values were changed in the Constants file during a rebase
but these values were being used as hardcoded strings by some classes
which were not updated and caused the app to make wrong api requests.