### PR TITLE
Fix white tab backgound bug

### DIFF
--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/BaseActivity.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/BaseActivity.java
@@ -54,4 +54,8 @@ public abstract class BaseActivity extends AppCompatActivity {
     public void setTabIndicator(int color){
         tabLayout.setSelectedTabIndicatorColor(color);
     }
+
+    public void setTabTextColor(int notSelectedColor,int selectedColor){
+        tabLayout.setTabTextColors(notSelectedColor, selectedColor);
+    }
 }

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/BaseActivity.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/BaseActivity.java
@@ -42,6 +42,9 @@ public abstract class BaseActivity extends AppCompatActivity {
 
         viewPager.setAdapter(pageAdapter);
         tabLayout.setupWithViewPager(viewPager);
+
+        int farthestTabToTheRight = tabs.size() - 1;
+        tabLayout.getTabAt(farthestTabToTheRight).select();
     }
 
     public void setTabBackground(int color) {

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/ConfigureGatewayWifiActivity.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/ConfigureGatewayWifiActivity.java
@@ -24,8 +24,9 @@ public class ConfigureGatewayWifiActivity extends BaseActivity {
         setupHeader(getString(R.string.configure_gateway_wifi_header_title), tabs);
 
         int backgroundColor = getResources().getColor(R.color.colorKnotGreen);
+        int tabSelectedTextColor = getResources().getColor(R.color.colorWhite);
         setTabBackground(backgroundColor);
-        setTabIndicator(backgroundColor);
+        setTabTextColor(backgroundColor, tabSelectedTextColor);
     }
 
 }

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/GatewayActivity.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/GatewayActivity.java
@@ -35,6 +35,11 @@ public class GatewayActivity extends BaseActivity {
         tabs.add(configureWiFiTab);
         tabs.add(gatewayConnectedTab);
 
+        int backgroundColor = getResources().getColor(R.color.colorWhite);
+        int tabIndicatorColor = getResources().getColor(R.color.colorKnotGreen);
+        setTabBackground(backgroundColor);
+        setTabIndicator(tabIndicatorColor);
+
         setupHeader(getString(R.string.gateway_header_title), tabs);
     }
 

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/LoginActivity.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/LoginActivity.java
@@ -27,8 +27,9 @@ public class LoginActivity extends BaseActivity {
             setupHeader(getString(R.string.login_header_title),tabs);
 
             int backgroundColor = getResources().getColor(R.color.colorKnotGreen);
+            int tabSelectedTextColor = getResources().getColor(R.color.colorWhite);
             setTabBackground(backgroundColor);
-            setTabIndicator(backgroundColor);
+            setTabTextColor(backgroundColor, tabSelectedTextColor);
     }
 
 }

--- a/app/src/main/res/layout/activity_header.xml
+++ b/app/src/main/res/layout/activity_header.xml
@@ -51,8 +51,8 @@
             android:id="@+id/tabs"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:background="@color/colorWhite"
             app:layout_constraintTop_toBottomOf="@+id/list_title"
-            app:tabBackground="@color/colorWhite"
             app:tabIndicatorColor="@color/colorKnotGreen"
             app:tabTextColor="@color/colorGrey"
             app:tabSelectedTextColor="@color/colorKnotGreen"/>


### PR DESCRIPTION
When visiting views that had only one tab, its background was white. This mistake is caused by the way tab was constructed (the "app" attribute in the XML overrides the setTabBackground method).

This problem is correcting in this patch, by removing the app attributes and  setting all tab-related configs in it's containing activity,