### PR TITLE
Add gateway/thing name at configuration activity

### DIFF
--- a/app/src/main/java/br/org/cesar/knot_setup_app/utils/Constants.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/utils/Constants.java
@@ -60,4 +60,7 @@ public class Constants{
 
     //KEYS FOR BUNDLES
     public static final String OPERATION = "operation";
+    public static final String GATEWAY_NAME = "gateway_name";
+    public static final String THING_NAME = "thing_name";
+
 }

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/ConfigureDeviceActivity.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/ConfigureDeviceActivity.java
@@ -8,6 +8,8 @@ import br.org.cesar.knot_setup_app.R;
 import br.org.cesar.knot_setup_app.view.configureDevice.ConfigureDeviceFragment;
 import br.org.cesar.knot_setup_app.model.Tab;
 
+import static br.org.cesar.knot_setup_app.utils.Constants.THING_NAME;
+
 public class ConfigureDeviceActivity extends BaseActivity {
 
     private ArrayList<Tab> tabs;
@@ -17,7 +19,8 @@ public class ConfigureDeviceActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
 
         tabs = new ArrayList<>();
-        Tab tab = new Tab(getString(R.string.configure_device_tab_name), new ConfigureDeviceFragment());
+        String thingName = getIntent().getStringExtra(THING_NAME);
+        Tab tab = new Tab(thingName, new ConfigureDeviceFragment());
         tabs.add(tab);
 
         setupHeader(getString(R.string.configure_device_header_title), tabs);

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/ConfigureGatewayWifiActivity.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/ConfigureGatewayWifiActivity.java
@@ -8,6 +8,8 @@ import br.org.cesar.knot_setup_app.R;
 import br.org.cesar.knot_setup_app.view.configureGatewayWifi.ConfigureGatewayWifiFragment;
 import br.org.cesar.knot_setup_app.model.Tab;
 
+import static br.org.cesar.knot_setup_app.utils.Constants.GATEWAY_NAME;
+
 public class ConfigureGatewayWifiActivity extends BaseActivity {
 
     private ArrayList<Tab> tabs;
@@ -17,8 +19,9 @@ public class ConfigureGatewayWifiActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
 
         tabs = new ArrayList<>();
-        Tab tab = new Tab(getString(R.string.configure_gateway_wifi_tab_name), new ConfigureGatewayWifiFragment());
 
+        String thingName = getIntent().getStringExtra(GATEWAY_NAME);
+        Tab tab = new Tab(thingName, new ConfigureGatewayWifiFragment());
         tabs.add(tab);
 
         setupHeader(getString(R.string.configure_gateway_wifi_header_title), tabs);

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/scan/ScanContract.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/scan/ScanContract.java
@@ -12,8 +12,8 @@ public interface ScanContract {
         void onDeviceFound(List<BluetoothDevice> deviceList);
         void onScanFail();
         void onBluetoothPermissionRequired();
-        void onGatewayWifiConfiguration();
-        void onThingSelected();
+        void onGatewayWifiConfiguration(String gatewayName);
+        void onThingSelected(String thingName);
         void setBluetoothFeedback(int visibility);
     }
 

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/scan/ScanFragment.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/scan/ScanFragment.java
@@ -34,6 +34,9 @@ import br.org.cesar.knot_setup_app.model.BluetoothDevice;
 import br.org.cesar.knot_setup_app.utils.Constants;
 import br.org.cesar.knot_setup_app.wrapper.LogWrapper;
 
+import static br.org.cesar.knot_setup_app.utils.Constants.GATEWAY_NAME;
+import static br.org.cesar.knot_setup_app.utils.Constants.THING_NAME;
+
 public class ScanFragment extends Fragment implements ViewModel {
 
     private ListView deviceListView;
@@ -87,14 +90,16 @@ public class ScanFragment extends Fragment implements ViewModel {
     }
 
     @Override
-    public void onGatewayWifiConfiguration() {
+    public void onGatewayWifiConfiguration(String gatewayName) {
         Intent intent = new Intent(context, ConfigureGatewayWifiActivity.class);
+        intent.putExtra(GATEWAY_NAME, gatewayName);
         startActivity(intent);
     }
 
     @Override
-    public void onThingSelected() {
+    public void onThingSelected(String thingName) {
         Intent intent = new Intent(context, ConfigureDeviceActivity.class);
+        intent.putExtra(THING_NAME, thingName);
         startActivity(intent);
     }
 

--- a/app/src/main/java/br/org/cesar/knot_setup_app/view/scan/ScanPresenter.java
+++ b/app/src/main/java/br/org/cesar/knot_setup_app/view/scan/ScanPresenter.java
@@ -125,9 +125,9 @@ public class ScanPresenter implements  Presenter {
         KnotSetupApplication.setBluetoothDevice(device);
 
         if(service == Constants.WIFI_CONFIGURATION_SERVICE_GATEWAY) {
-            viewModel.onGatewayWifiConfiguration();
+            viewModel.onGatewayWifiConfiguration(device.getDevice().getName());
         } else if (service == Constants.OT_SETTINGS_SERVICE) {
-            viewModel.onThingSelected();
+            viewModel.onThingSelected(device.getDevice().getName());
         }
     }
 


### PR DESCRIPTION
Add the name of the selected thing or gateway in its respective
configuration activity.

This allows the user to double check if they selected the right gateway
or thing.